### PR TITLE
Add publish action and first release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish
+
+on:
+    push:
+        tags: [ v* ]
+
+jobs:
+    check:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-java@v2
+              with:
+                  java-version: '11'
+                  distribution: 'adopt'
+            - run: ./gradlew check
+
+    publish:
+        needs: check
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-java@v2
+              with:
+                  java-version: '11'
+                  distribution: 'adopt'
+            - id: get_tag_version
+              run: echo "::set-output name=VERSION::${GITHUB_REF#refs/tags/v}"
+            - run: ./gradlew assemble
+            - run: ./gradlew publishPlugins -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}
+              env:
+                  ORG_GRADLE_PROJECT_version: ${{ steps.get_tag_version.outputs.VERSION }}
+              shell: bash
+
+    release:
+        needs: publish
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/create-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  tag_name: ${{ github.ref }}
+                  release_name: ${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,7 @@ This file documents all notable changes, following the [Keep a Changelog](https:
 
 ## Unreleased
 
+## 1.0.0 - 2021-12-23
+
 ### Added
 - Public release

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Also see plugin page in [Gradle Plugin Portal](https://plugins.gradle.org/plugin
 - `checkKotlinWarningBaseline` Check that all warnings are in warning baseline files for each source set in project/module.
 - `removeKotlinWarningBaseline` Remove all warning baselines files in project/module.
 
+## Release
+
+To release a new version, ensure `CHANGELOG.md` is up-to-date, and push the corresponding tag (e.g., `v1.2.3`). GitHub Actions handles the rest.
+
 ## Licence
 
 Released under the [MIT License](https://opensource.org/licenses/MIT).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
     mavenCentral()
 }
 group = "com.doist.gradle"
-version = "1.0.0"
+version = property("version") as String
 
 dependencies {
     compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     `java-gradle-plugin`
     id("maven-publish")
     id("com.gradle.plugin-publish").version("0.16.0")
-    // id("com.doist.gradle.kotlin-warning-baseline").version("+")
+    id("com.doist.gradle.kotlin-warning-baseline").version("+")
 }
 
 repositories {


### PR DESCRIPTION
This PR adds github action to publish plugin to Gradle Plugin Portal and makes first release.

Release is under review currently, likely because it's the first release. See [here](https://github.com/Doist/kotlin-warning-baseline/actions/runs/1616009330)

> Your new plugin com.doist.gradle.kotlin-warning-baseline has been submitted for approval by Gradle engineers. The request should be processed within the next few days, at which point you will be contacted via email.

