### PR TITLE
build: set better timeout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 jobs:
     check:
         runs-on: ubuntu-latest
+        timeout-minutes: 60
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-java@v2
@@ -18,6 +19,7 @@ jobs:
     publish:
         needs: check
         runs-on: ubuntu-latest
+        timeout-minutes: 60
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-java@v2
@@ -35,6 +37,7 @@ jobs:
     release:
         needs: publish
         runs-on: ubuntu-latest
+        timeout-minutes: 60
         steps:
             - uses: actions/checkout@v2
             - uses: actions/create-release@v1

--- a/.github/workflows/warning-check.yml
+++ b/.github/workflows/warning-check.yml
@@ -13,6 +13,7 @@ jobs:
   warning-check:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 60
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Set missing timeouts to 60 to avoid using the default of 6 hours.

See https://github.com/Doist/Issues/issues/5259