### PR TITLE
Fix `Windows` incompatibility

### DIFF
--- a/src/main/kotlin/com/doist/gradle/KotlinWarningBaselinePlugin.kt
+++ b/src/main/kotlin/com/doist/gradle/KotlinWarningBaselinePlugin.kt
@@ -48,6 +48,7 @@ class KotlinWarningBaselinePlugin : Plugin<Project> {
 
             warningFiles.set(kotlinTaskMap.values)
             baselineFiles.set(baselines.values)
+            this.pathConvertor.set(pathConvertor)
 
             dependsOn(kotlinTaskMap.keys + clean)
             mustRunAfter(clean)

--- a/src/main/kotlin/com/doist/gradle/KotlinWarningBaselinePlugin.kt
+++ b/src/main/kotlin/com/doist/gradle/KotlinWarningBaselinePlugin.kt
@@ -1,6 +1,7 @@
 package com.doist.gradle
 
 import com.doist.gradle.collector.WarningFileCollector
+import com.doist.gradle.convertor.PathSeparatorConvertor
 import com.doist.gradle.spec.TaskInGraphSpec
 import com.doist.gradle.task.CheckKotlinWarningBaselineTask
 import com.doist.gradle.task.RemoveKotlinWarningBaselineTask
@@ -29,12 +30,13 @@ class KotlinWarningBaselinePlugin : Plugin<Project> {
             val sourceSetRoot = it.findRootDirectory()
             sourceSetRoot to File(sourceSetRoot, extension.baselineFileName)
         }
+        val pathConvertor = PathSeparatorConvertor()
 
         val kotlinTaskMap = tasks.withType<AbstractKotlinCompile<*>>()
             .filter { task -> extension.skipSpecs.none { it.isSatisfiedBy(task) } }
             .associateWith { File(buildDir, "kotlin-warnings/${it.name}.txt") }
             .onEach { (task, file) ->
-                val collector = WarningFileCollector(task, file, baselines.keys)
+                val collector = WarningFileCollector(task, file, pathConvertor, baselines.keys)
                 gradle.taskGraph.addTaskExecutionListener(collector)
             }
 

--- a/src/main/kotlin/com/doist/gradle/collector/WarningFileCollector.kt
+++ b/src/main/kotlin/com/doist/gradle/collector/WarningFileCollector.kt
@@ -1,5 +1,6 @@
 package com.doist.gradle.collector
 
+import com.doist.gradle.convertor.PathSeparatorConvertor
 import com.doist.gradle.ext.create
 import org.gradle.api.Task
 import org.gradle.api.execution.TaskExecutionListener
@@ -10,15 +11,17 @@ import java.io.File
 class WarningFileCollector(
     private val task: Task,
     private val file: File,
+    private val pathConvertor: PathSeparatorConvertor,
     sourceSets: Set<File>
 ) : TaskExecutionListener {
-    private val prefixSet = sourceSets.mapTo(mutableSetOf()) { "w: ${it.parent}/" }
+    private val prefixSet =
+        sourceSets.mapTo(mutableSetOf()) { "w: ${it.parent}${File.separatorChar}" }
 
     private val outputListener = StandardOutputListener { line ->
         for (prefix in prefixSet) {
             if (line.startsWith(prefix)) {
                 file.takeIf { !it.exists() }?.create()
-                file.appendText("${line.removePrefix(prefix)}\n")
+                file.appendText("${pathConvertor.toUnix(line.removePrefix(prefix))}\n")
                 break
             }
         }

--- a/src/main/kotlin/com/doist/gradle/convertor/PathSeparatorConvertor.kt
+++ b/src/main/kotlin/com/doist/gradle/convertor/PathSeparatorConvertor.kt
@@ -2,6 +2,7 @@ package com.doist.gradle.convertor
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
+private const val WINDOWS_SEPARATOR = "\\\\"
 private const val UNIX_SEPARATOR = "/"
 
 fun PathSeparatorConvertor() = when {
@@ -11,6 +12,8 @@ fun PathSeparatorConvertor() = when {
 
 interface PathSeparatorConvertor {
     fun toUnix(text: CharSequence): CharSequence
+
+    fun toPlatform(text: CharSequence): CharSequence
 }
 
 private class WindowsToUnixPathSeparatorConvertor : PathSeparatorConvertor {
@@ -20,10 +23,18 @@ private class WindowsToUnixPathSeparatorConvertor : PathSeparatorConvertor {
     // "w: C:\work\Composer.kt: (1, 1): \Deprecated\ in \Java\" line. The rest are behind ".kt".
     private val findWindowsSeparatorsRegex = """(?<=(\w|:))?\\(?=(\w|\\)*\.kt)""".toRegex()
 
+    // Finds each "/" before ".kt" if they're separated by letters/digits/underscores.
+    private val findUnixSeparatorsRegex = """(?<=(\w|:))?/(?=(\w|/)*\.kt)""".toRegex()
+
     override fun toUnix(text: CharSequence) =
         text.replace(findWindowsSeparatorsRegex, UNIX_SEPARATOR)
+
+    override fun toPlatform(text: CharSequence) =
+        text.replace(findUnixSeparatorsRegex, WINDOWS_SEPARATOR)
 }
 
 private class KeepAsIsPathSeparatorConvertor : PathSeparatorConvertor {
     override fun toUnix(text: CharSequence) = text
+
+    override fun toPlatform(text: CharSequence) = text
 }

--- a/src/main/kotlin/com/doist/gradle/convertor/PathSeparatorConvertor.kt
+++ b/src/main/kotlin/com/doist/gradle/convertor/PathSeparatorConvertor.kt
@@ -1,0 +1,29 @@
+package com.doist.gradle.convertor
+
+import org.apache.tools.ant.taskdefs.condition.Os
+
+private const val UNIX_SEPARATOR = "/"
+
+fun PathSeparatorConvertor() = when {
+    Os.isFamily(Os.FAMILY_WINDOWS) -> WindowsToUnixPathSeparatorConvertor()
+    else -> KeepAsIsPathSeparatorConvertor()
+}
+
+interface PathSeparatorConvertor {
+    fun toUnix(text: CharSequence): CharSequence
+}
+
+private class WindowsToUnixPathSeparatorConvertor : PathSeparatorConvertor {
+    // Finds each "\" before ".kt" if they're separated by letters/digits/underscores.
+    //
+    // E.g. only the first two "\" characters will be found in
+    // "w: C:\work\Composer.kt: (1, 1): \Deprecated\ in \Java\" line. The rest are behind ".kt".
+    private val findWindowsSeparatorsRegex = """(?<=(\w|:))?\\(?=(\w|\\)*\.kt)""".toRegex()
+
+    override fun toUnix(text: CharSequence) =
+        text.replace(findWindowsSeparatorsRegex, UNIX_SEPARATOR)
+}
+
+private class KeepAsIsPathSeparatorConvertor : PathSeparatorConvertor {
+    override fun toUnix(text: CharSequence) = text
+}

--- a/src/main/kotlin/com/doist/gradle/ext/IterableExt.kt
+++ b/src/main/kotlin/com/doist/gradle/ext/IterableExt.kt
@@ -7,5 +7,5 @@ fun Iterable<File>.readSetOfLines(): Set<String> = flatMapTo(mutableSetOf()) {
 }
 
 fun Iterable<String>.filterByBaseline(baseline: File): List<String> = filter {
-    it.startsWith("${baseline.parentFile.name}${File.separatorChar}")
+    it.startsWith("${baseline.parentFile.name}/")
 }

--- a/src/main/kotlin/com/doist/gradle/task/CheckKotlinWarningBaselineTask.kt
+++ b/src/main/kotlin/com/doist/gradle/task/CheckKotlinWarningBaselineTask.kt
@@ -1,11 +1,14 @@
 package com.doist.gradle.task
 
+import com.doist.gradle.convertor.PathSeparatorConvertor
 import com.doist.gradle.ext.filterByBaseline
 import com.doist.gradle.ext.readSetOfLines
 import com.doist.gradle.ext.readWarningLines
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 import java.io.File
@@ -17,15 +20,20 @@ abstract class CheckKotlinWarningBaselineTask : DefaultTask() {
     @get:InputFiles
     abstract val baselineFiles: ListProperty<File>
 
+    @get:Input
+    abstract val pathConvertor: Property<PathSeparatorConvertor>
+
     @TaskAction
     fun write() {
+        val pathConvertor = pathConvertor.get()
         val warningSet = warningFiles.get().readSetOfLines()
         val diff = baselineFiles.get().flatMap { baselineFile ->
             val baseline = baselineFile.readWarningLines()
             val current = warningSet.filterByBaseline(baselineFile)
             (current - baseline).map {
                 val parentFile = baselineFile.parentFile
-                it.replaceFirst(parentFile.name, parentFile.absolutePath)
+                pathConvertor.toPlatform(it).toString()
+                    .replaceFirst(parentFile.name, parentFile.absolutePath)
             }
         }
         if (diff.isNotEmpty()) {


### PR DESCRIPTION
## Description
Plugin doesn't work properly on `Windows`. 

#### `writeKotlinWarningBaseline` task
Warnings collector (`WarningFileCollector`) expected that all systems have the same file path style. Therefore, it couldn't match warnings in logs and path to module. It was fixed by using the platform specific `File.separator`. 

However, all warning logs are still to be saved with UNIX style paths. That causes additional work on Windows machines, but it was chosen because:
- using two path styles in baseline files looks messy.
- the most part of developers can understand UNIX path style.
- *NIX-based system are more widely used among developers and
on CI "runners". 

####  `checkKotlinWarningBaseline` task
Also, there's "fixed" `checkKotlinWarningBaseline` task output.   
It displays Windows style paths in warnings returned by failed task. It looks more "natural" and visually matches with other warning in `Gradle` output.

Closes #5 