### PR TITLE
ci: Remove deprecated set-output usage

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
                   java-version: '11'
                   distribution: 'adopt'
             - id: get_tag_version
-              run: echo "::set-output name=VERSION::${GITHUB_REF#refs/tags/v}"
+              run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
             - run: ./gradlew assemble
             - run: ./gradlew publishPlugins -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}
               env:


### PR DESCRIPTION
## Overview

`set-output` is being deprecated and will cause failures June 2023. Updated to the recommended approach.

## Reference

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.com/Doist/infrastructure-backlog/issues/481

