### PR TITLE
chore: Update actions to support NodeJS 20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - uses: actions/setup-java@v2
               with:
                   java-version: '11'
@@ -21,7 +21,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - uses: actions/setup-java@v2
               with:
                   java-version: '11'
@@ -39,7 +39,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 60
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - uses: actions/create-release@v1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/warning-check.yml
+++ b/.github/workflows/warning-check.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Java
         uses: actions/setup-java@v2


### PR DESCRIPTION
This PR updates the actions to versions that no longer rely on NodeJS 16, which has reached its end of life. By upgrading the actions, we ensure compatibility with the latest NodeJS 20 runtime.

For https://github.com/Doist/infrastructure-backlog/issues/628
